### PR TITLE
Fixed bug with flags in pending intent

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "com.publicmediainstitute.lumpenradio"
         minSdkVersion 16
         targetSdkVersion 33
-        versionCode 5
-        versionName "1.1.1"
+        versionCode 6
+        versionName "1.1.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/publicmediainstitute/lumpenradio/RadioService.kt
+++ b/app/src/main/java/com/publicmediainstitute/lumpenradio/RadioService.kt
@@ -117,7 +117,11 @@ class RadioService : Service() {
 
         val pendingIntent: PendingIntent? = TaskStackBuilder.create(this).run {
             addNextIntentWithParentStack(intent)
-            getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT)
+            var flags = PendingIntent.FLAG_UPDATE_CURRENT
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                flags = flags or PendingIntent.FLAG_IMMUTABLE
+            }
+            getPendingIntent(0, flags)
         }
 
         val builder = NotificationCompat.Builder(this, getChannelId())


### PR DESCRIPTION
When starting the Lumpen Radio app on a phone with Android OS M or higher the app would crash when starting the radio stream.

This is fixed by adding an "Immutability" flag in the Pending Intent constructor block.